### PR TITLE
Develop

### DIFF
--- a/bin/run_pca_cv.R
+++ b/bin/run_pca_cv.R
@@ -315,12 +315,18 @@ RunPCACV <- function(
 print(paste0("Data matrix has ", dim(x = data)[1], " rows, ", dim(x = data)[2], " columns."))
 
 
+# Set to 
+if(args$`to-n-pc` > dim(x = data)[2]) {
+	print(paste0("Setting --to-n-pc parameter to ", dim(x = data)[1], " instead of ", args$`to-n-pc`, "."))
+}
+to_npcs <- min(dim(x = data)[1], args$`to-n-pc`)
+
 # Run
 out <- RunPCACV(
 	data = data,
 	k = args$`k-fold`,
 	from = args$`from-n-pc`,
-	to = args$`to-n-pc`,
+	to = to_npcs,
 	by = args$`by-n-pc`,
 	maxit = args$`max-iters`,
 	seed = args$`seed`,

--- a/bin/run_pca_cv.R
+++ b/bin/run_pca_cv.R
@@ -339,10 +339,17 @@ if(args$`to-n-pc` > data_min_dim) {
 	}
 	k <- 5
 	print(paste0("The k-fold parameter is decreased to ", k, "."))
-	data_min_dim <- min(nrow(x = data), ncol(x = data) / k)
 	from_npcs <- 2
 	to_npcs <- data_min_dim
 	by_npcs <- 1
+	repeat {
+		pc <- seq(from = from_npcs, to = to_npcs, by = by_npcs)
+		if(length(x = pc) < 50) {
+			break
+		} else {
+			by_npcs <- by_npcs + 1
+		}
+	}
 	print(paste0("Setting --from-n-pc parameter to ", from_npcs, " instead of ", args$`from-n-pc`, "."))
 	print(paste0("Setting --to-n-pc parameter to ", to_npcs, " instead of ", args$`to-n-pc`, "."))
 	print(paste0("Setting --by-n-pc parameter to ", by_npcs, " instead of ", args$`by-n-pc`, "."))

--- a/pcacv.config
+++ b/pcacv.config
@@ -13,6 +13,7 @@ params {
             // seed = ''
             // verbose = ''
             // devaultSVD = ''
+            // nPCFallback = 0
         }
     }
 

--- a/processes/runPCACV.nf
+++ b/processes/runPCACV.nf
@@ -36,11 +36,11 @@ process PCACV__FIND_OPTIMAL_NPCS {
             --seed ${params.global.seed} \
             ${(processParams.containsKey('accessor')) ? '--accessor "' + processParams.accessor.replace('$','\\$') + '"': ''} \
             ${(processParams.containsKey('useVariableFeatures')) ? '--use-variable-features ' + processParams.useVariableFeatures: ''} \
-            ${(processParams.containsKey('kFold')) ? '--k-fold ' + processParams.libraries: ''} \
+            ${(processParams.containsKey('kFold')) ? '--k-fold ' + processParams.kFold: ''} \
             ${(processParams.containsKey('fromNPC')) ? '--from-n-pc ' + processParams.fromNPC: ''} \
             ${(processParams.containsKey('toNPC')) ? '--to-n-pc ' + processParams.toNPC: ''} \
             ${(processParams.containsKey('byNPC')) ? '--by-n-pc ' + processParams.byNPC: ''} \
-            ${(processParams.containsKey('maxIters')) ? '--max-iters ' + processParams.libraries: ''} \
+            ${(processParams.containsKey('maxIters')) ? '--max-iters ' + processParams.maxIters: ''} \
             --n-cores ${task.cpus} \
             ${(processParams.containsKey('defaultSVD')) ? '--default-svd ' + processParams.defaultSVD: ''} \
             ${(processParams.containsKey('verbose')) ? '--verbose ' + processParams.verbose: ''} \

--- a/processes/runPCACV.nf
+++ b/processes/runPCACV.nf
@@ -40,6 +40,7 @@ process PCACV__FIND_OPTIMAL_NPCS {
             ${(processParams.containsKey('fromNPC')) ? '--from-n-pc ' + processParams.fromNPC: ''} \
             ${(processParams.containsKey('toNPC')) ? '--to-n-pc ' + processParams.toNPC: ''} \
             ${(processParams.containsKey('byNPC')) ? '--by-n-pc ' + processParams.byNPC: ''} \
+            ${(processParams.containsKey('nPCFallback')) ? '--n-pc-fallback ' + processParams.nPCFallback: ''} \
             ${(processParams.containsKey('maxIters')) ? '--max-iters ' + processParams.maxIters: ''} \
             --n-cores ${task.cpus} \
             ${(processParams.containsKey('defaultSVD')) ? '--default-svd ' + processParams.defaultSVD: ''} \


### PR DESCRIPTION
- Closes #14 
- Fix wrong arguments (maxIters, kFold) passed to executable run_pca_cv.R dbc5496
- Closes #15
- Adapt *-n-pc and k parameters if violating requirement of data dimensionality d6ebc81
- Add mechanism to automatically find good parameters for --from-n-pc, --to-n-pc, --by-n-pc and --k-fold in case those params are violating data dimensionality. 63fa667